### PR TITLE
Keep s as part of the same word in initialism

### DIFF
--- a/initialisms.go
+++ b/initialisms.go
@@ -45,7 +45,16 @@ func (ini *Initialisms) CamelToSnake(name string) string {
 	for i := 0; i < len(r); {
 		isUpper, isLetter = unicode.IsUpper(r[i]), unicode.IsLetter(r[i])
 		// append _ when last was not upper and not letter
-		if (lastWasLetter && isUpper) || (lastWasIsm && isLetter) {
+		switch {
+		case lastWasLetter && isUpper:
+			s += "_"
+		case lastWasIsm && isLetter:
+			// UUIDs should be converted to uuids but
+			// SLAsample should still remain sla_sample.
+			hasFurtherChar := len(r) > i+1 && unicode.IsLetter(r[i+1]) && !unicode.IsUpper(r[i+1])
+			if r[i] == 's' && !hasFurtherChar {
+				break
+			}
 			s += "_"
 		}
 		// determine next to append to r

--- a/snaker_test.go
+++ b/snaker_test.go
@@ -40,6 +40,9 @@ func TestCamelToSnake(t *testing.T) {
 		{"UIDzuuidUIDIDUUID", "uid_zuuid_uid_id_uuid"},
 		{"UIDzUUIDUIDidUUID", "uid_z_uuid_uid_id_uuid"},
 		{"UIDzUUID-UIDidUUID", "uid_z_uuid-uid_id_uuid"},
+		{"sampleIDs", "sample_ids"},
+		{"someUUIDs", "some_uuids"},
+		{"SLAsample", "sla_sample"},
 	}
 	for i, test := range tests {
 		if v := CamelToSnake(test.s); v != test.exp {


### PR DESCRIPTION
This PR special cases `s` to make `IDs` convert into `ids` instead of `id_s`.